### PR TITLE
feat: bypass server certificate config

### DIFF
--- a/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
@@ -111,14 +111,14 @@ public class MeshConnectClient : IMeshConnectClient
                 }
 
                 bool isValidCA = mailboxConfiguration.serverSideCertCollection
-                    .Any(caCert => caCert.Thumbprint == cert.Issuer);
+                    .Any(caCert => caCert.Thumbprint == cert.Thumbprint);
                 if (!isValidCA)
                 {
                     _logger.LogError("Server certificate is not issued by a trusted CA!");
                     return false;
                 }
 
-                return true;;
+                return true;
 
             };
         }

--- a/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
@@ -100,12 +100,26 @@ public class MeshConnectClient : IMeshConnectClient
                 {
                     chain.ChainPolicy.CustomTrustStore.Add(caCert);
                 }
-                if (cert != null)
+                if (cert == null)
                 {
-                    // Rebuild the chain with added certs
-                    return chain.Build(cert);
+                    return false;
                 }
-                return false;
+                // Rebuild the chain with added certs
+                if (!chain.Build(cert))
+                {
+                    return false;
+                }
+
+                bool isValidCA = mailboxConfiguration.serverSideCertCollection
+                    .Any(caCert => caCert.Thumbprint == cert.Issuer);
+                if (!isValidCA)
+                {
+                    _logger.LogError("Server certificate is not issued by a trusted CA!");
+                    return false;
+                }
+
+                return true;;
+
             };
         }
 

--- a/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Clients/MeshConnectClient.cs
@@ -82,7 +82,13 @@ public class MeshConnectClient : IMeshConnectClient
             handler.SslProtocols = SslProtocols.Tls12;
             handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, chain, sslPolicyErrors) =>
             {
-                if (sslPolicyErrors == System.Net.Security.SslPolicyErrors.None)
+
+                if(_meshConnectConfiguration.BypassServerCertificateValidation)
+                {
+                    _logger.LogWarning("Bypassing Server Certificate Validation");
+                    return true;
+                }
+                else if (sslPolicyErrors == System.Net.Security.SslPolicyErrors.None)
                 {
                     return true; // Everything is fine
                 }

--- a/application/DotNetMeshClient/NHS.Mesh.Client/Configuration/MeshConnectConfiguration.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Configuration/MeshConnectConfiguration.cs
@@ -54,4 +54,6 @@ public class MeshConnectConfiguration : IMeshConnectConfiguration
     public bool ProxyUseDefaultCredentials { get; set; }
     /// <summary>Gets the chunk size in bytes for sending chunked messages 19Mb limit outside of HSCN 100Mb limit within</summary>
     public int ChunkSize { get; set; }
+    /// <summary>Flag if the Servers Certificate is Checked against the CA Chain</summary>
+    public bool BypassServerCertificateValidation { get; set; }
 }

--- a/application/DotNetMeshClient/NHS.Mesh.Client/Contracts/Configurations/IMeshConnectConfiguration.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Contracts/Configurations/IMeshConnectConfiguration.cs
@@ -53,4 +53,6 @@ public interface IMeshConnectConfiguration
     bool ProxyUseDefaultCredentials { get; set; }
     /// <summary>Gets the chunk size in bytes for sending chunked messages 19Mb limit outside of HSCN 100Mb limit within</summary>
     int ChunkSize { get; set; }
+    /// <summary>Flag if the Servers Certificate is Checked against the CA Chain</summary>
+    public bool BypassServerCertificateValidation { get; set; }
 }

--- a/application/DotNetMeshClient/NHS.Mesh.Client/Extensions/MeshMailboxBuilder.cs
+++ b/application/DotNetMeshClient/NHS.Mesh.Client/Extensions/MeshMailboxBuilder.cs
@@ -28,7 +28,8 @@ public class MeshMailboxBuilder
             MeshApiInboxUriPath = "inbox",
             MeshApiOutboxUriPath = "outbox",
             MeshApiAcknowledgeUriPath = "status/acknowledged",
-            ChunkSize = 19 * 1024 * 1024// below the 20mb limit for external
+            ChunkSize = 19 * 1024 * 1024,// below the 20mb limit for external
+            BypassServerCertificateValidation = false
         };
 
         options(_meshConnectConfiguration);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding a flag to the Mesh config to allow for the server side Certificate to be bypassed

## Context

Some environments don't have proper certificates, this will allow us to connect to them without issues when config is set

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
